### PR TITLE
Fixing activesupport dependency

### DIFF
--- a/rmega.gemspec
+++ b/rmega.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake"
 
   gem.add_dependency "httpclient"
-  gem.add_dependency 'active_support'
+  gem.add_dependency 'activesupport'
   gem.add_dependency "execjs"
 end


### PR DESCRIPTION
Hello,

The dependency `active_support` is an alias to `active_support = 3.0.0`.
Changing to `activesupport`, it will work with latest rails version.

Thx!
